### PR TITLE
Update testem config, MIT -> Apache 2.0 license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "Small description for ember-osf-collections goes here",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": "",
   "directories": {
     "doc": "doc",

--- a/testem.js
+++ b/testem.js
@@ -1,7 +1,12 @@
+/* eslint-env node */
+
+const DotReporter = require('testem/lib/reporters/dot_reporter');
+
 module.exports = {
     framework: 'mocha',
     test_page: 'tests/index.html?hidepassed',
     disable_watching: true,
+    reporter: new DotReporter(),
     launch_in_ci: [
         'Chrome',
         'Firefox',
@@ -11,18 +16,11 @@ module.exports = {
         'Firefox',
     ],
     browser_args: {
-        Chrome: {
-            mode: 'ci',
-            args: [
-                // --no-sandbox is needed when running Chrome inside a container
-                process.env.TRAVIS ? '--no-sandbox' : null,
-
-                '--disable-gpu',
-                '--headless',
-                '--remote-debugging-port=0',
-                '--window-size=1440,900',
-            ].filter(Boolean),
-        },
+        Chrome: [
+            '--headless',
+            '--no-sandbox',
+            '--remote-debugging-port=9222',
+        ],
         Firefox: [
             '-headless',
         ],


### PR DESCRIPTION
- `--no-sandbox` is required to run in docker, but doesn't make a difference outside docker
- `--disable-gpu` is no longer needed
- Add reporter for coverage (need to add ember-cli-code-coverage later on)

Use `yarn test -l chrome` or `yarn test -l firefox` to run the tests against a single browser